### PR TITLE
require Bundler with no version constraint

### DIFF
--- a/sudo.gemspec
+++ b/sudo.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.3'
 
   spec.add_development_dependency 'pry-byebug', '~> 3'
-  spec.add_development_dependency 'bundler', '>= 2.0.1'
+  spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake', '~> 12.0'
   spec.add_development_dependency 'rspec'
 

--- a/sudo.gemspec
+++ b/sudo.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.3'
 
   spec.add_development_dependency 'pry-byebug', '~> 3'
-  spec.add_development_dependency 'bundler', '~> 1.3'
+  spec.add_development_dependency 'bundler', '>= 2.0.1'
   spec.add_development_dependency 'rake', '~> 12.0'
   spec.add_development_dependency 'rspec'
 


### PR DESCRIPTION
@voltechs this should fix build errors we were having recently by not requiring the old version of Bundler anymore.