### PR TITLE
Replace deprecated File.exists? with File.exist?

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Sudo
 
+## 0.3.0 _(...)_
+- Works on ruby 3.2
+
 ## 0.2.0 _(November 05, 2018)_
 - Modernized
 - Tests

--- a/lib/sudo/system.rb
+++ b/lib/sudo/system.rb
@@ -18,7 +18,7 @@ module Sudo
       end
 
       def unlink(file)
-        if file and File.exists? file
+        if file and File.exist? file
           system("sudo rm -f #{file}") or
           raise(FileStillExists, "Couldn't delete #{file}")
         end

--- a/lib/sudo/wrapper.rb
+++ b/lib/sudo/wrapper.rb
@@ -69,7 +69,7 @@ module Sudo
       finalizer = Finalizer.new(pid: @sudo_pid, socket: @socket)
       ObjectSpace.define_finalizer(self, finalizer)
 
-      if wait_for(timeout: 1){File.exists? @socket}
+      if wait_for(timeout: 1){File.exist? @socket}
         @proxy = DRbObject.new_with_uri(server_uri)
       else
         raise RuntimeError, "Couldn't create DRb socket #{@socket}"
@@ -83,7 +83,7 @@ module Sudo
     def running?
       true if (
         @sudo_pid and Process.exists? @sudo_pid and
-        @socket   and File.exists?    @socket   and
+        @socket   and File.exist?    @socket   and
         @proxy
       )
     end


### PR DESCRIPTION
File.exists? was deprecated in Ruby 2.1.0 and has been removed in Ruby 3.2.0.

https://bugs.ruby-lang.org/issues/17391
https://www.reddit.com/r/ruby/comments/1196wti/psa_and_a_little_rant_fileexists_direxists/